### PR TITLE
Thread pooling for the Spawn util

### DIFF
--- a/libs/Spawn/Spawn.luau
+++ b/libs/Spawn/Spawn.luau
@@ -14,8 +14,8 @@ end
 return function<T...>(Callback: (T...) -> (), ...: T...)
 	local Thread
 	if #FreeThreads > 0 then
-		Thread = FreeThreads[1]
-		FreeThreads[1], FreeThreads[#FreeThreads] = FreeThreads[#FreeThreads], nil
+		Thread = FreeThreads[#FreeThreads]
+		FreeThreads[#FreeThreads] = nil
 	else
 		Thread = coroutine.create(Yielder)
 		coroutine.resume(Thread)

--- a/libs/Spawn/Spawn.luau
+++ b/libs/Spawn/Spawn.luau
@@ -1,23 +1,25 @@
-local FreeThread: thread? = nil
+local FreeThreads: { thread } = {}
 
-local function FunctionPasser(Callback, ...)
-	local AquiredThread = FreeThread
-	FreeThread = nil
+local function RunCallback(Callback, Thread, ...)
 	Callback(...)
-	FreeThread = AquiredThread
+	table.insert(FreeThreads, Thread)
 end
 
 local function Yielder()
 	while true do
-		FunctionPasser(coroutine.yield())
+		RunCallback(coroutine.yield())
 	end
 end
 
 return function<T...>(Callback: (T...) -> (), ...: T...)
-	if not FreeThread then
-		FreeThread = coroutine.create(Yielder)
-		coroutine.resume(FreeThread :: any)
+	local Thread
+	if #FreeThreads > 0 then
+		Thread = FreeThreads[1]
+		FreeThreads[1], FreeThreads[#FreeThreads] = FreeThreads[#FreeThreads], nil
+	else
+		Thread = coroutine.create(Yielder)
+		coroutine.resume(Thread)
 	end
 
-	task.spawn(FreeThread :: thread, Callback, ...)
+	task.spawn(Thread, Callback, Thread, ...)
 end


### PR DESCRIPTION
The main reason for using `task.spawn` is to spawn functions that yield so they dont block the thread, there's really no point in doing `task.spawn` on a synchronous function because the thread will still block until that function finishes, simply calling the function will be much faster and if it's one that can error, just pcall it and handle the error which would still be miles faster.

Basically a benchmark like this is misleading:

![RobloxStudioBeta_ECXEDbD6BZ](https://github.com/red-blox/Util/assets/60469830/d07c8224-fa8a-4214-b0b4-d5afebbda68b)

Because the real winner is directly calling the function (it's that very teeny tiny red bar):

![image](https://github.com/red-blox/Util/assets/60469830/eb40aeac-9337-4421-9ca1-7dcbc8aa9e7f)

---

Let's now see how it will fair against `task.spawn` when it comes to async functions, we can predict that it'll be slower because it'll end up creating a new coroutine and resuming it just like `task.spawn` already does but with overhead, and that's exactly what we see:

![image](https://github.com/red-blox/Util/assets/60469830/8694ffcb-53ca-4bde-a468-a55107f78516)

So to make this util a lot more useful, especially when it's supposed to be shared across your DataModel, we can simply cache the coroutines we create and use them when a future async function needs it, which shows results like this when the pool is fully saturated:

![image](https://github.com/red-blox/Util/assets/60469830/574d20d4-1d65-4fa2-ac6b-013ccc8e8ff8)

Now we actually beat `task.spawn` by ~40%

Memory usage is also minimal because coroutines dont use up much of it, 100k referenced coroutines would use up about 100mb in memory. We also only cache a thread when the function returns, which means threads that error will be garbage collected.

---

All the benchmarks are ran using [boatbomber's benchmark plugin](https://boatbomber.itch.io/benchmarker) with [this](https://pastebin.com/AxV6Kf6p) ModuleScript.