### PR TITLE
Add more utility functions to the library

### DIFF
--- a/libs/Future/Future.luau
+++ b/libs/Future/Future.luau
@@ -107,7 +107,15 @@ local function Try<T..., A...>(Callback: (A...) -> T..., ...: A...): Future<(boo
 	return Future(pcall, Callback, ...)
 end
 
+-- Use try as we don't know if the future could error or not, and erroring futures create memory leaks.
+local function ToFuture<T..., A...>(Callback: (A...) -> T...): (A...) -> Future<(boolean, T...)>
+	return function(...)
+		return Try(Callback, ...)
+	end
+end
+
 return {
 	new = Future,
 	Try = Try,
+	ToFuture = ToFuture,
 }

--- a/libs/Future/Future.luau
+++ b/libs/Future/Future.luau
@@ -140,6 +140,28 @@ local function All<T...>(futures: { Future<T...> }): Future<{ () -> T... }>
 	end, futures)
 end
 
+local function Any<T...>(futures: { Future<T...> }): Future<T...>
+	return Future(function(futures: { Future<T...> })
+		local thread = coroutine.running()
+		local returned = false
+
+		for _, future in futures do
+			if future:IsComplete() then
+				returned = true
+				return future:Unwrap()
+			end
+
+			future:After(function(...)
+				if not returned then
+					returned = true
+					task.spawn(thread, ...)
+				end
+			end)
+		end
+
+		return coroutine.yield()
+	end, futures)
+end
 
 return {
 	new = Future,
@@ -147,4 +169,5 @@ return {
 	ToFuture = ToFuture,
 	All = All,
 	AllSingle = AllSingle,
+	Any = Any,
 }

--- a/libs/Future/Future.luau
+++ b/libs/Future/Future.luau
@@ -114,8 +114,37 @@ local function ToFuture<T..., A...>(Callback: (A...) -> T...): (A...) -> Future<
 	end
 end
 
+-- Only works for futures returning one value (which to be honest is most cases, hence why it gets its own function)
+-- Has a relatively unintuitive type error when using a future with more than one return value, so it doesn't get to be called just "All"
+local function AllSingle<T>(futures: { Future<T> }): Future<{ T }>
+	return Future(function(futures: { Future<T> }): { T }
+		local futureValues: any = table.create(#futures)
+		for k, future in futures do
+			futureValues[k] = future:Await()
+		end
+		return futureValues
+	end, futures)
+end
+
+-- Works for futures returning multiple values, but without table tuple types, we can only return a function that returns a tuple to preserve typing.
+local function All<T...>(futures: { Future<T...> }): Future<{ () -> T... }>
+	return Future(function(futures: { Future<T...> }): { () -> T... }
+		local futureValues: any = table.create(#futures)
+		for k, future in futures do
+			local values = table.pack(future:Await())
+			futureValues[k] = function()
+				return table.unpack(values)
+			end
+		end
+		return futureValues
+	end, futures)
+end
+
+
 return {
 	new = Future,
 	Try = Try,
 	ToFuture = ToFuture,
+	All = All,
+	AllSingle = AllSingle,
 }

--- a/libs/Future/Future.luau
+++ b/libs/Future/Future.luau
@@ -163,6 +163,12 @@ local function Any<T...>(futures: { Future<T...> }): Future<T...>
 	end, futures)
 end
 
+local function Value<T...>(...: T...): Future<T...>
+	return Future(function(...)
+		return ...
+	end, ...)
+end
+
 return {
 	new = Future,
 	Try = Try,
@@ -170,4 +176,5 @@ return {
 	All = All,
 	AllSingle = AllSingle,
 	Any = Any,
+	Value = Value,
 }

--- a/libs/Future/Future.luau
+++ b/libs/Future/Future.luau
@@ -114,18 +114,6 @@ local function ToFuture<T..., A...>(Callback: (A...) -> T...): (A...) -> Future<
 	end
 end
 
--- Only works for futures returning one value (which to be honest is most cases, hence why it gets its own function)
--- Has a relatively unintuitive type error when using a future with more than one return value, so it doesn't get to be called just "All"
-local function AllSingle<T>(futures: { Future<T> }): Future<{ T }>
-	return Future(function(futures: { Future<T> }): { T }
-		local futureValues: any = table.create(#futures)
-		for k, future in futures do
-			futureValues[k] = future:Await()
-		end
-		return futureValues
-	end, futures)
-end
-
 -- Works for futures returning multiple values, but without table tuple types, we can only return a function that returns a tuple to preserve typing.
 local function All<T...>(futures: { Future<T...> }): Future<{ () -> T... }>
 	return Future(function(futures: { Future<T...> }): { () -> T... }
@@ -174,7 +162,6 @@ return {
 	Try = Try,
 	ToFuture = ToFuture,
 	All = All,
-	AllSingle = AllSingle,
 	Any = Any,
 	Value = Value,
 }


### PR DESCRIPTION
This adds utility functions to the Future library, so common ones can come packaged with the library instead of developers having to write them themselves.

I took inspiration from [Evaera's Promise utils](https://eryn.io/roblox-lua-promise/api/Promise) regarding what functions to add.

The PR proposes the addition of 5 functions.

### ToFuture
Takes in some function, and returns a function that wraps it in a Future when called, passing in any given arguments to it.
Useful for quickly turning any yielding function into a Future-returning one.

### All
Takes in an array of Futures, and returns a new Future which waits for them all to resolve, then returns an array of functions. These functions, when called, return the values returned by their respective Future.
The reason we can't just return the values directly, is that the only way to store the values at each key is to pack them - but this loses the type information. However, if we just use closures which return the values as a regular tuple, then we can still get types, and the developer can choose how to process the tuple.

### AllSingle
The same as the previous function, but only works for Futures that return one value. It causes a type error if you pass in a Future that returns more than one value. The benefit here, is that we don't need to return a table of functions - we can just insert the value into the table directly because we know there is only one.
Considering many futures will only have one return value, I think this function is worth adding even if it only works for this subset of possible Futures.

There is also a potential problem, where if a developer has Futures that return more than one value, but they only care about the first value, they should be able to use `AllSingle`, however this will still raise a type error.
I can't really think of a solution to this, but it should be rare enough to not matter.

### Any
Takes in a table of Futures, and returns a Future which resolves when the first Future in the table resolves.

### Value
Takes in some values, and returns a Future that immediately resolves to those values.

# Draft Status
Still need to write docs, but wanted to get some thoughts first before I write them.